### PR TITLE
Fixed destroy method

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 node_modules
+package-lock.json

--- a/index.js
+++ b/index.js
@@ -30,6 +30,7 @@ function createFile (name, opts) {
   var fs = null
   var file = null
   var entry = null
+  var toDestroy = null
   var readers = []
   var writers = []
 
@@ -46,6 +47,7 @@ function createFile (name, opts) {
   }
 
   function close (req) {
+    toDestroy = entry
     readers = writers = entry = file = fs = null
     req.callback(null)
   }
@@ -55,13 +57,15 @@ function createFile (name, opts) {
   }
 
   function destroy (req) {
-    entry.remove(ondone, onerror)
+    toDestroy.remove(ondone, onerror)
 
     function ondone () {
+      toDestroy = null
       req.callback(null, null)
     }
 
     function onerror (err) {
+      toDestroy = null
       req.callback(err, null)
     }
   }

--- a/index.js
+++ b/index.js
@@ -47,7 +47,6 @@ function createFile (name, opts) {
   }
 
   function close (req) {
-    toDestroy = entry
     readers = writers = entry = file = fs = null
     req.callback(null)
   }
@@ -77,7 +76,7 @@ function createFile (name, opts) {
         fs = res
         mkdirp(parentFolder(name), function () {
           fs.root.getFile(name, {create: true}, function (e) {
-            entry = e
+            entry = toDestroy = e
             entry.file(function (f) {
               file = f
               req.callback(null)


### PR DESCRIPTION
Hi @mafintosh, 

I try to use the destroy method and it gives me an undefined object error during the: `entry.remove(ondone, onerror)`

The issue is that we call the `close` method before doing the destroy and it's setting to null the entry object.